### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ import ApiCalendar from 'react-google-calendar-api';
 
 ### Typescript Import
 ```
-import * as ApiCalendar from 'react-google-calendar-api/ApiCalendar';
+import ApiCalendar from 'react-google-calendar-api/ApiCalendar';
 ```
 
 Create a file apiGoogleconfig.json in the root directory with your googleApi clientId and ApiKey.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ npm install --save react-google-calendar-api
 ```
 import ApiCalendar from 'react-google-calendar-api';
 ```
+
+### Typescript Import
+```
+import * as ApiCalendar from 'react-google-calendar-api/ApiCalendar';
+```
+
 Create a file apiGoogleconfig.json in the root directory with your googleApi clientId and ApiKey.
 https://console.developers.google.com/flows/enableapi?apiid=calendar.
 


### PR DESCRIPTION
Hey!
Noticed you just released this library (thank god it saved me from figuring out google calendar).
Just noticed a small thing when importing the library to my project, I needed to import as
```
import ApiCalendar from 'react-google-calendar-api/ApiCalendar';
```
in typescript. There was some error regarding the original way not detecting the types despite it being supported. 